### PR TITLE
33 Add Google's Lighthouse website analysis tool

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,7 +13,7 @@ jobs:
       - name: npm install, build
         run: |
           npm ci
-          npm run build
+          npm run build-localhost
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.14.x

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,3 +18,5 @@ jobs:
         run: |
           npm install -g @lhci/cli@0.14.x
           lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,20 @@
+name: Lighthouse CI
+on: [push]
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+      - name: npm install, build
+        run: |
+          npm ci
+          npm run build
+      - name: run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli@0.14.x
+          lhci autorun

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    ci: {
+      upload: {
+        target: 'temporary-public-storage',
+      },
+    },
+  };

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,7 +1,11 @@
 module.exports = {
     ci: {
-      upload: {
-        target: 'temporary-public-storage',
-      },
+        collect: {
+            url: ['http://localhost:3000/'],
+            startServerCommand: 'npm run serve',
+        },
+        upload: {
+            target: 'temporary-public-storage',
+        },
     },
-  };
+};

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -7,5 +7,8 @@ module.exports = {
         upload: {
             target: 'temporary-public-storage',
         },
+        assert: {
+            preset: 'lighthouse:recommended',
+        },
     },
 };

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -7,8 +7,5 @@ module.exports = {
         upload: {
             target: 'temporary-public-storage',
         },
-        assert: {
-            preset: 'lighthouse:recommended',
-        },
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
+        "cross-env": "^7.0.3",
         "fake-indexeddb": "^6.0.0",
         "jest": "^27.5.1"
       }
@@ -6730,6 +6731,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "build-localhost": "cross-env PUBLIC_URL=/ react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "serve": "serve -s build"
   },
   "eslintConfig": {
     "extends": [
@@ -56,6 +58,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
+    "cross-env": "^7.0.3",
     "fake-indexeddb": "^6.0.0",
     "jest": "^27.5.1"
   }


### PR DESCRIPTION
Lisätty Google Lighthouse analyysi työkalu CI pipelineen. Jokaisella pushilla ajetaan analyysi. Raportti on saatavilla jossain Googlen palvelimilla parin viikon ajan, sitten se poistuu. Se on meille riittävä. Linkki löytyy "All checks" ja sieltä details tuon "lhci/url/" kohdalla. Pipeline ei erikseen failaa vaikkei tulokset olisi hyviä, se ainoastaan näyttää tulokset.

Harkitsin main-haaran tuloksien laittamista Readme:hen, mutta se ei vaikuttanut niin suoraviivaiselta kuin toivoin, niin jätin tekemättä. Hyöty siitä olisi myös minimaalinen.

Raportista voi nyt esim. PR:n tarkastelun yhteydessä katsoa karkeasti onko suurta muutosta tullut ja mitä asioita voisi olla hyvä mahdollisesti korjata.