### PR TITLE
102 Temporarily disable offline caching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ root.render(
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://cra.link/PWA
-serviceWorkerRegistration.register();
+serviceWorkerRegistration.unregister();
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
Ei ollut järkeä lähteä tässä vaiheessa hakkaamaan päätä seinään online-first cachingin kanssa. Varsinkin kun se ei ole vaadittu ominaisuus. Otetaan koko caching pois päältä (service workerit pois) ja katsotaan jos ne myöhemmin laitetaan takaisin.