### PR TITLE
#124 Vaihdettu PWA:n taustaväri vihreäksi

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -47,5 +47,5 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#06705B",
-  "background_color": "#ffffff"
+  "background_color": "#06705B"
 }


### PR DESCRIPTION
Tässä issuessa vaihdettiin PWA:n lataus-vaiheen taustaväri sovelluksen teeman mukaiseksi vihreäksi muuttamalla manifest.json tiedostossa "background_color" ominaisuutta. Nyt PWA:ta avattaessa pitäisi näkyä sovelluksen logo vihreällä taustalla valkoisen sijaan.