### PR TITLE
123 Blue highlight problem

### DIFF
--- a/src/components/universal/BackButton.css
+++ b/src/components/universal/BackButton.css
@@ -4,7 +4,6 @@
     background: none;
     border: none;
     color: var(--sp-white);
-    cursor: pointer;
     padding: none;
   }
   

--- a/src/components/universal/DeleteButton.css
+++ b/src/components/universal/DeleteButton.css
@@ -3,7 +3,6 @@
   align-items: center;
   background: none;
   border: none;
-  cursor: pointer;
   margin-left: auto;
   padding: 2px 3px;
 }

--- a/src/components/universal/EditButton.css
+++ b/src/components/universal/EditButton.css
@@ -3,7 +3,6 @@
     align-items: center;
     background: none;
     border: none;
-    cursor: pointer;
     margin-left: auto; 
     padding: 2px 3px;
   }

--- a/src/styles/ManagePath.css
+++ b/src/styles/ManagePath.css
@@ -88,7 +88,6 @@
 
 .delete-icon {
     font-size: var(--sp-icon-size-small);
-    cursor: pointer;
     color: var(--sp-black);
     margin-left: 20px;
 }
@@ -100,7 +99,6 @@
     padding: 15px;
     background-color: var(--sp-white);
     border-radius: var(--sp-button-border-radius);
-    cursor: pointer;
     width: 60%;
     margin-top: 50px;
 }

--- a/src/styles/NewWord.css
+++ b/src/styles/NewWord.css
@@ -74,7 +74,6 @@
     background-color: #06705B;
     border-radius: 0;
     border: none;
-    cursor: pointer;
     color: white;
     font-size: var(--sp-heading-5);
     font-weight: bold;
@@ -99,7 +98,6 @@
     font-weight: bold;
     border-radius: var(--sp-button-border-radius);
     border: none;
-    cursor: pointer;
     width: 30%;
     text-align: center;
 }

--- a/src/styles/PathSelection.css
+++ b/src/styles/PathSelection.css
@@ -68,7 +68,6 @@
   height: 100%;
   font-size: var(--sp-heading-2);
   font-weight: bold;
-  cursor: pointer;
   text-transform: capitalize;
   border-radius: var(--sp-button-border-radius) 0 0
     var(--sp-button-border-radius);
@@ -88,7 +87,6 @@
 .add-path-icon {
   font-size: var(--sp-icon-size-large);
   color: var(--sp-white);
-  cursor: pointer;
   transition: color 0.3s ease;
 }
 
@@ -150,7 +148,6 @@
   font-weight: bold;
   border-radius: var(--sp-button-border-radius);
   border: none;
-  cursor: pointer;
   width: 50%;
   transition:
     background-color 0.3s ease,

--- a/src/styles/Settings.css
+++ b/src/styles/Settings.css
@@ -19,7 +19,6 @@ body {
 .back-button {
   color: white;
   font-size: 24px;
-  cursor: pointer;
 }
 
 .settings-about-container {
@@ -57,7 +56,6 @@ body {
 
 .setting-item input[type='checkbox'] {
   transform: scale(1.5);
-  cursor: pointer;
 }
 
 .about-info {


### PR DESCRIPTION
Tarkoituksena korjata mobiilinäkymässä näkyvät siniset highlightit painikkeita klikatessa. Yritin korjata poistamalla koodista cursor: pointer; -rivit, koska mobiilinäkymässä ei ole oleellinen (sovellus kuitenkin mobiilipohjalle lähtökohtaisesti) ja oletin tämän highlightin ja kopiointi mahdollisuuksien johtuvan siitä. Vaikea testata, kun ei pääse mobiilista tarkistamaan oliko oikea syy. Koin kuitenkin sen olevan selkein ero highlight ja ei-highlight nappien välillä. Closes #123 