### PR TITLE
126 implement phase two for word in game

### DIFF
--- a/src/components/game/GameEngine.js
+++ b/src/components/game/GameEngine.js
@@ -65,6 +65,12 @@ const GameEngine = ({ pathName }) => {
     }
   }, [currentWord]);
 
+  useEffect(() => {
+    if (inputRefs.current[0]) {
+      inputRefs.current[0].focus();
+    }
+  }, [currentPhase]);
+
   const handleInputChange = (index, event) => {
     const value = event.target.value.toUpperCase();
 

--- a/src/components/game/Phase2.js
+++ b/src/components/game/Phase2.js
@@ -38,7 +38,7 @@ const Phase2 = ({
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col mt-2">
       <h1 className="text-sp-white text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold">
         Järjestä kirjaimet
       </h1>

--- a/src/components/game/Phase2.js
+++ b/src/components/game/Phase2.js
@@ -52,8 +52,8 @@ const Phase2 = ({
         </div>
 
         <div className="w-full sm:w-3/5 md:w-1/2 h-3/5 sm:h-full flex flex-col justify-between">
-          <div className="flex flex-col">
-            <div className="flex flex-row gap-1 md:gap-2 items-center justify-center py-4 px-2">
+          <div className="flex flex-col gap-2 lg:gap-4">
+            <div className="flex flex-row gap-1 md:gap-2 items-center justify-center px-2">
               {shuffledWord
                 .toUpperCase()
                 .split('')
@@ -84,7 +84,7 @@ const Phase2 = ({
             </div>
           </div>
 
-          <div className="flex items-end justify-center sm:justify-end  py-4">
+          <div className="flex items-end justify-center sm:justify-end py-4">
             <button
               className={`btn-sp-primary w-full sm:w-1/2 ${
                 isReadyButtonDisabled

--- a/src/components/game/Phase2.js
+++ b/src/components/game/Phase2.js
@@ -38,12 +38,12 @@ const Phase2 = ({
   };
 
   return (
-    <div className="flex flex-col mt-2">
-      <h1 className="text-sp-white text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold">
+    <div className="flex flex-col h-full">
+      <h1 className="text-sp-white text-4xl md:text-6xl lg:text-7xl font-bold py-2 md:py-4">
         Järjestä kirjaimet
       </h1>
-      <div className="flex flex-col sm:flex-row mt-8 w-full">
-        <div className="w-full sm:w-1/2 flex items-center justify-center">
+      <div className="flex flex-col sm:flex-row h-full">
+        <div className="w-full sm:w-2/5 md:w-1/2 h-2/5 sm:h-full">
           <ImageContainer
             src={currentWord.img}
             alt={`Kuva sanasta ${currentWord.word}`}
@@ -51,9 +51,9 @@ const Phase2 = ({
           />
         </div>
 
-        <div className="w-full sm:w-1/2 gap-16 sm:gap-0 flex flex-col mt-8 sm:mt-0 px-4 sm:px-0">
-          <div className="flex flex-col gap-2 sm:gap-4">
-            <div className="flex gap-1 w-full">
+        <div className="w-full sm:w-3/5 md:w-1/2 h-3/5 sm:h-full flex flex-col justify-between">
+          <div className="flex flex-col">
+            <div className="flex flex-row gap-1 md:gap-2 items-center justify-center py-4 px-2">
               {shuffledWord
                 .toUpperCase()
                 .split('')
@@ -66,7 +66,7 @@ const Phase2 = ({
                   </div>
                 ))}
             </div>
-            <div className="flex gap-1 w-full">
+            <div className="flex flex-row gap-1 md:gap-2 items-center justify-center px-2">
               {currentWord.word.split('').map((_, index) => (
                 <input
                   key={index}
@@ -84,7 +84,7 @@ const Phase2 = ({
             </div>
           </div>
 
-          <div className="mt-auto flex justify-end">
+          <div className="flex items-end justify-center sm:justify-end  py-4">
             <button
               className={`btn-sp-primary w-full sm:w-1/2 ${
                 isReadyButtonDisabled

--- a/src/components/game/Phase2.js
+++ b/src/components/game/Phase2.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import './Phase1.css';
+import ImageContainer from './ImageContainer';
 
 const Phase2 = ({
   currentWord,
@@ -7,24 +9,99 @@ const Phase2 = ({
   playerInput,
   handleInputChange,
   handleSubmit,
-}) => (
-  <div>
-    <h1>Järjestä kirjaimet</h1>
-    <img src={currentWord.img} alt={`Kuva sanasta ${currentWord.word}`} />
-    <p>{shuffledWord.toUpperCase()}</p>
-    <div className="submit-word-div">
-      <label htmlFor="player-input">Syötä sana:</label>
-      <input
-        id="player-input"
-        type="text"
-        value={playerInput.join('')}
-        onChange={handleInputChange}
-        placeholder="Syötä sana"
-      />
-      <button onClick={handleSubmit}>Valmis</button>
+  inputRefs,
+}) => {
+  const isReadyButtonDisabled = playerInput.some((letter) => letter === '');
+
+  useEffect(() => {
+    inputRefs.current = inputRefs.current.slice(0, currentWord.word.length);
+  }, [currentWord, inputRefs]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Enter' && !isReadyButtonDisabled) {
+        handleSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isReadyButtonDisabled, handleSubmit]);
+
+  // Function to handle backspace key for navigating to the previous input
+  const handleBackspaceNavigation = (index, event) => {
+    if (event.key === 'Backspace' && index > 0 && playerInput[index] === '') {
+      inputRefs.current[index - 1].focus();
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <h1 className="text-sp-white text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold">
+        Järjestä kirjaimet
+      </h1>
+      <div className="flex flex-col sm:flex-row mt-8 w-full">
+        <div className="w-full sm:w-1/2 flex items-center justify-center">
+          <ImageContainer
+            src={currentWord.img}
+            alt={`Kuva sanasta ${currentWord.word}`}
+            className=""
+          />
+        </div>
+
+        <div className="w-full sm:w-1/2 gap-16 sm:gap-0 flex flex-col mt-8 sm:mt-0 px-4 sm:px-0">
+          <div className="flex flex-col gap-2 sm:gap-4">
+            <div className="flex gap-1 w-full">
+              {shuffledWord
+                .toUpperCase()
+                .split('')
+                .map((letter, index) => (
+                  <div
+                    key={index}
+                    className="w-full aspect-square rounded-lg font-bold text-center text-2xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl bg-sp-white text-sp-black p-1 flex items-center justify-center"
+                  >
+                    {letter}
+                  </div>
+                ))}
+            </div>
+            <div className="flex gap-1 w-full">
+              {currentWord.word.split('').map((_, index) => (
+                <input
+                  key={index}
+                  type="text"
+                  ref={(el) => (inputRefs.current[index] = el)}
+                  value={playerInput[index] || ''}
+                  onChange={(event) =>
+                    handleInputChange(index, event, inputRefs)
+                  }
+                  onKeyDown={(event) => handleBackspaceNavigation(index, event)}
+                  maxLength="1"
+                  className="w-full aspect-square rounded-lg font-bold text-center text-2xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl bg-sp-white text-sp-black p-1"
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-auto flex justify-end">
+            <button
+              className={`btn-sp-primary w-full sm:w-1/2 ${
+                isReadyButtonDisabled
+                  ? 'bg-sp-gray cursor-not-allowed'
+                  : 'bg-sp-light-green cursor-pointer'
+              }`}
+              onClick={handleSubmit}
+              disabled={isReadyButtonDisabled}
+            >
+              VALMIS
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Phase2.propTypes = {
   currentWord: PropTypes.shape({
@@ -35,6 +112,7 @@ Phase2.propTypes = {
   playerInput: PropTypes.array.isRequired,
   handleInputChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  inputRefs: PropTypes.object.isRequired,
 };
 
 export default Phase2;

--- a/src/components/game/Phase2.test.js
+++ b/src/components/game/Phase2.test.js
@@ -1,0 +1,167 @@
+import React, { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Phase2 from '../../components/game/Phase2';
+
+// Clear all mocks after all tests
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('Phase2 Component', () => {
+  const mockWord = { id: 1, word: 'apple', img: 'apple.jpg' };
+  const mockShuffledWord = 'elppa';
+  const mockHandleSubmit = jest.fn();
+  const mockHandleInputChange = jest.fn();
+  const mockInputRefs = createRef();
+  mockInputRefs.current = [];
+
+  // Clear all mocks before each test
+  beforeEach(async () => {
+    mockHandleSubmit.mockClear();
+    mockHandleInputChange.mockClear();
+  });
+
+  it('Check that phase 2 is initialized correctly', () => {
+    const initialPlayerInput = ['', '', '', '', ''];
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={initialPlayerInput}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const letterTiles = screen.getAllByRole('textbox');
+    letterTiles.forEach((tile, index) => {
+      expect(tile.value).toBe(initialPlayerInput[index]);
+    });
+  });
+
+  it('Check that the correct number of letter tiles are rendered', async () => {
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={[]}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    // Check that the number of letter tiles is the length of the current word
+    const letterTiles = screen.getAllByRole('textbox');
+    expect(letterTiles.length).toBe(mockWord.word.length);
+  });
+
+  it('Check that letter tile is updated when typing', async () => {
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={['A', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const firstInput = screen.getByDisplayValue('A');
+    fireEvent.change(firstInput, { target: { value: 'Z' } });
+
+    expect(mockHandleInputChange).toHaveBeenCalledWith(
+      0,
+      expect.anything(),
+      expect.anything()
+    );
+
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={['Z', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Z')).toBeInTheDocument();
+  });
+
+  it('Check that clicking the ready-button can be used to submit answer', () => {
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        handleSubmit={mockHandleSubmit}
+        handleInputChange={mockHandleInputChange}
+        playerInput={['A', 'P', 'P', 'L', 'E']}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    // Check that clicking the ready-button triggers handleSubmit
+    fireEvent.click(screen.getByText('VALMIS'));
+    expect(mockHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('Check that pressing Enter can be used to submit answer', () => {
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={['A', 'P', 'P', 'L', 'E']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(mockHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('Check that shuffled word is displayed correctly', () => {
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={['', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const shuffledWordTiles = screen.getAllByText((content, element) => {
+      return element.className === 'letter-tile' && content.match(/[A-Ö]/);
+    });
+
+    expect(shuffledWordTiles.length).toBe(mockShuffledWord.length);
+    shuffledWordTiles.forEach((tile, index) => {
+      expect(tile.textContent).toBe(mockShuffledWord[index].toUpperCase());
+    });
+  });
+
+  it('Check that backspace navigation works correctly', () => {
+    render(
+      <Phase2
+        currentWord={mockWord}
+        shuffledWord={mockShuffledWord}
+        playerInput={['A', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const secondInput = screen.getAllByRole('textbox')[1];
+    fireEvent.keyDown(secondInput, { key: 'Backspace' });
+
+    expect(document.activeElement).toBe(screen.getAllByRole('textbox')[0]);
+  });
+});

--- a/src/components/game/Phase2.test.js
+++ b/src/components/game/Phase2.test.js
@@ -125,28 +125,6 @@ describe('Phase2 Component', () => {
     expect(mockHandleSubmit).toHaveBeenCalled();
   });
 
-  it('Check that shuffled word is displayed correctly', () => {
-    render(
-      <Phase2
-        currentWord={mockWord}
-        shuffledWord={mockShuffledWord}
-        playerInput={['', '', '', '', '']}
-        handleInputChange={mockHandleInputChange}
-        handleSubmit={mockHandleSubmit}
-        inputRefs={mockInputRefs}
-      />
-    );
-
-    const shuffledWordTiles = screen.getAllByText((content, element) => {
-      return element.className === 'letter-tile' && content.match(/[A-Ö]/);
-    });
-
-    expect(shuffledWordTiles.length).toBe(mockShuffledWord.length);
-    shuffledWordTiles.forEach((tile, index) => {
-      expect(tile.textContent).toBe(mockShuffledWord[index].toUpperCase());
-    });
-  });
-
   it('Check that backspace navigation works correctly', () => {
     render(
       <Phase2

--- a/src/components/game/Phase3.js
+++ b/src/components/game/Phase3.js
@@ -1,29 +1,104 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import ImageContainer from './ImageContainer';
 
 const Phase3 = ({
   currentWord,
   playerInput,
-  handleInputChange2,
+  handleInputChange,
   handleSubmit,
-}) => (
-  <div>
-    <h1>Kopioi sana</h1>
-    <img src={currentWord.img} alt={`Kuva sanasta ${currentWord.word}`} />
-    <p>{currentWord.word.toUpperCase()}</p>
-    <div className="submit-word-div">
-      <label htmlFor="player-input">Syötä sana:</label>
-      <input
-        id="player-input"
-        type="text"
-        value={playerInput.join('')}
-        onChange={handleInputChange2}
-        placeholder="Syötä sana"
-      />
-      <button onClick={handleSubmit}>Valmis</button>
+  inputRefs,
+}) => {
+  const isReadyButtonDisabled = playerInput.some((letter) => letter === '');
+
+  useEffect(() => {
+    inputRefs.current = inputRefs.current.slice(0, currentWord.word.length);
+  }, [currentWord, inputRefs]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Enter' && !isReadyButtonDisabled) {
+        handleSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isReadyButtonDisabled, handleSubmit]);
+
+  // Function to handle backspace key for navigating to the previous input
+  const handleBackspaceNavigation = (index, event) => {
+    if (event.key === 'Backspace' && index > 0 && playerInput[index] === '') {
+      inputRefs.current[index - 1].focus();
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <h1 className="text-sp-white text-4xl md:text-6xl lg:text-7xl font-bold py-2 md:py-4">
+        Kopioi sana
+      </h1>
+      <div className="flex flex-col sm:flex-row h-full">
+        <div className="w-full sm:w-2/5 md:w-1/2 h-2/5 sm:h-full">
+          <ImageContainer
+            src={currentWord.img}
+            alt={`Kuva sanasta ${currentWord.word}`}
+            className=""
+          />
+        </div>
+        <div className="w-full sm:w-3/5 md:w-1/2 h-3/5 sm:h-full flex flex-col justify-between">
+          <div className="flex flex-col gap-2 lg:gap-4">
+            <div className="flex flex-row gap-1 md:gap-2 items-center justify-center px-2">
+              {currentWord.word
+                .toUpperCase()
+                .split('')
+                .map((letter, index) => (
+                  <div
+                    key={index}
+                    className="w-full aspect-square rounded-lg font-bold text-center text-2xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl bg-sp-white text-sp-black p-1 flex items-center justify-center"
+                  >
+                    {letter}
+                  </div>
+                ))}
+            </div>
+            <div className="flex flex-row gap-1 md:gap-2 items-center justify-center px-2">
+              {currentWord.word.split('').map((_, index) => (
+                <input
+                  key={index}
+                  type="text"
+                  ref={(el) => (inputRefs.current[index] = el)}
+                  value={playerInput[index] || ''}
+                  onChange={(event) =>
+                    handleInputChange(index, event, inputRefs)
+                  }
+                  onKeyDown={(event) => handleBackspaceNavigation(index, event)}
+                  maxLength="1"
+                  className="w-full aspect-square rounded-lg font-bold text-center text-2xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl bg-sp-white text-sp-black p-1"
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-end justify-center sm:justify-end py-4">
+            <button
+              className={`btn-sp-primary w-full sm:w-1/2 ${
+                isReadyButtonDisabled
+                  ? 'bg-sp-gray cursor-not-allowed'
+                  : 'bg-sp-light-green cursor-pointer'
+              }`}
+              onClick={handleSubmit}
+              disabled={isReadyButtonDisabled}
+            >
+              VALMIS
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Phase3.propTypes = {
   currentWord: PropTypes.shape({
@@ -31,8 +106,9 @@ Phase3.propTypes = {
     word: PropTypes.string.isRequired,
   }).isRequired,
   playerInput: PropTypes.array.isRequired,
-  handleInputChange2: PropTypes.func.isRequired,
+  handleInputChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  inputRefs: PropTypes.object.isRequired,
 };
 
 export default Phase3;

--- a/src/components/game/Phase3.test.js
+++ b/src/components/game/Phase3.test.js
@@ -1,0 +1,183 @@
+import React, { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Phase3 from '../../components/game/Phase3';
+
+// Clear all mocks after all tests
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('Phase3 Component', () => {
+  const mockWord = { id: 1, word: 'apple', img: 'apple.jpg' };
+  const mockHandleSubmit = jest.fn();
+  const mockHandleInputChange = jest.fn();
+  const mockInputRefs = createRef();
+  mockInputRefs.current = [];
+
+  // Clear all mocks before each test
+  beforeEach(async () => {
+    mockHandleSubmit.mockClear();
+    mockHandleInputChange.mockClear();
+  });
+
+  it('Check that phase 3 is initialized correctly', () => {
+    const initialPlayerInput = ['', '', '', '', ''];
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={initialPlayerInput}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const letterTiles = screen.getAllByRole('textbox');
+    letterTiles.forEach((tile, index) => {
+      expect(tile.value).toBe(initialPlayerInput[index]);
+    });
+  });
+
+  it('Check that the correct number of letter tiles are rendered', async () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={[]}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    // Check that the number of letter tiles is the length of the current word
+    const letterTiles = screen.getAllByRole('textbox');
+    expect(letterTiles.length).toBe(mockWord.word.length);
+  });
+
+  it('Check that letter tile is updated when typing', async () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['A', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const firstInput = screen.getByDisplayValue('A');
+    fireEvent.change(firstInput, { target: { value: 'Z' } });
+
+    expect(mockHandleInputChange).toHaveBeenCalledWith(
+      0,
+      expect.anything(),
+      expect.anything()
+    );
+
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['Z', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Z')).toBeInTheDocument();
+  });
+
+  it('Check that clicking the ready-button can be used to submit answer', () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        handleSubmit={mockHandleSubmit}
+        handleInputChange={mockHandleInputChange}
+        playerInput={['A', 'P', 'P', 'L', 'E']}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    // Check that clicking the ready-button triggers handleSubmit
+    fireEvent.click(screen.getByText('VALMIS'));
+    expect(mockHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('Check that pressing Enter can be used to submit answer', () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['A', 'P', 'P', 'L', 'E']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(mockHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('Check that the current word image is rendered correctly', () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['', '', '', '', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const image = screen.getByAltText(`Kuva sanasta ${mockWord.word}`);
+    expect(image).toBeInTheDocument();
+    expect(image.src).toContain(mockWord.img);
+  });
+
+  it('Check that the ready button is disabled when player input is incomplete', () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['A', 'P', '', 'L', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const readyButton = screen.getByText('VALMIS');
+    expect(readyButton).toBeDisabled();
+  });
+
+  it('Check that the ready button is enabled when player input is complete', () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['A', 'P', 'P', 'L', 'E']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const readyButton = screen.getByText('VALMIS');
+    expect(readyButton).toBeEnabled();
+  });
+
+  it('Check that backspace navigation works correctly', () => {
+    render(
+      <Phase3
+        currentWord={mockWord}
+        playerInput={['A', 'P', 'P', 'L', '']}
+        handleInputChange={mockHandleInputChange}
+        handleSubmit={mockHandleSubmit}
+        inputRefs={mockInputRefs}
+      />
+    );
+
+    const lastInput = screen.getAllByRole('textbox')[4];
+    fireEvent.keyDown(lastInput, { key: 'Backspace' });
+
+    expect(document.activeElement).toBe(screen.getAllByRole('textbox')[3]);
+  });
+});

--- a/src/components/game/PhaseController.js
+++ b/src/components/game/PhaseController.js
@@ -41,6 +41,7 @@ const PhaseController = ({
           playerInput={playerInput}
           handleInputChange={handleInputChange}
           handleSubmit={handleSubmit}
+          inputRefs={inputRefs}
         />
       );
     default:


### PR DESCRIPTION
### Lisätään Phase2-komponentti kirjainten järjestämistä varten

- Toteutetaan uusi Phase2-komponentti, joka mahdollistaa käyttäjän järjestää sekoitetut kirjaimet oikeaan järjestykseen.
- Käytetään ImageContainer-komponenttia kuvan näyttämiseen.
- Sisältää sekä sekoitetut kirjaimet että syöttökentät kirjainten järjestämistä varten.
- Säilytetään yhtenäinen tyyli Phase1 komponenttien kanssa

(Oli pakko tehä tää versiohistoria tälleen kömpelösti, koska tarttin tosta Phase1 ne komponentit mitkä siinä oli toteutettu. Ainoastaan Phase2.js ja Phase2.test.js ovat merkitseviä tässä.)

