### PR TITLE
121 Longer word gets hidden behind picture

### DIFF
--- a/src/styles/ManagePath.css
+++ b/src/styles/ManagePath.css
@@ -62,7 +62,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 80%;
+  width: 100%;
   background-color: var(--sp-white);
   padding: 15px 20px;
   border-radius: var(--sp-button-border-radius);
@@ -77,6 +77,9 @@
   white-space: nowrap;
   overflow: hidden;
   text-transform: capitalize;
+  display: inline-block;
+  white-space: normal;
+  word-break: break-word; 
 }
 
 .word-image {
@@ -84,6 +87,7 @@
   width: 50px;
   height: 50px;
   margin-right: 20px;
+  margin-left: 5px;
 }
 
 .add-word {


### PR DESCRIPTION
Issuessa oli tarkoitus muokata oman polun sanojen listaa toimimaan myös pitkien sanojen kanssa, ilman että loppu sanasta piiloutuu kuvan taakse. Nyt sanalistan sanojen leveyttä on hieman suurennettu, jonka lisäksi sanat on muutettu jatkumaan seuraavalle riville, jos tarpeen. Closes #121 