### PR TITLE
179 improve game scalability for tablet

### DIFF
--- a/src/components/game/GameEngine.js
+++ b/src/components/game/GameEngine.js
@@ -62,17 +62,8 @@ const GameEngine = ({ pathName }) => {
     if (currentWord) {
       setPlayerInput(Array(currentWord.word.length).fill(''));
       inputRefs.current.forEach((input) => input?.blur());
-      if (inputRefs.current[0]) {
-        inputRefs.current[0].focus();
-      }
     }
   }, [currentWord]);
-
-  useEffect(() => {
-    if (inputRefs.current[0]) {
-      inputRefs.current[0].focus();
-    }
-  }, [currentPhase]);
 
   const handleInputChange = (index, event) => {
     const value = event.target.value.toUpperCase();

--- a/src/components/game/ImageContainer.css
+++ b/src/components/game/ImageContainer.css
@@ -6,6 +6,21 @@
 }
 
 .image-container img {
-  height: 20vw;
-  width: 20vw;
+  height: 35vw;
+  width: 35vw;
+}
+
+/* Style for Tablets in Horizontal mode */
+@media (min-width: 1000px) and (min-height: 400px) and (orientation: landscape) {
+  .image-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .image-container img {
+    height: 50vh;
+    width: 50vh;
+  }
 }

--- a/src/components/game/ImageContainer.js
+++ b/src/components/game/ImageContainer.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './ImageContainer.css';
 
 const ImageContainer = ({ src, alt }) => (
-  <div className="flex h-full items-center justify-center sm:items-start p-4">
+  <div className="image-container flex items-center justify-center sm:items-start p-4">
     <img className="h-full aspect-square" src={src} alt={alt} />
   </div>
 );

--- a/src/components/game/Phase1.js
+++ b/src/components/game/Phase1.js
@@ -35,7 +35,7 @@ const Phase1 = ({
     }
   };
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col">
       <h1 className="text-sp-white text-4xl md:text-6xl lg:text-7xl font-bold py-2 md:py-4">
         Kirjoita sana
       </h1>
@@ -48,7 +48,7 @@ const Phase1 = ({
           />
         </div>
 
-        <div className="w-full sm:w-3/5 md:w-1/2 h-3/5 sm:h-full flex flex-col justify-between ">
+        <div className="w-full sm:w-3/5 md:w-1/2 h-3/5 flex flex-col justify-between ">
           <div className="flex flex-row gap-1 md:gap-2 items-center justify-center py-4 px-2">
             {currentWord.word.split('').map((_, index) => (
               <input
@@ -59,11 +59,11 @@ const Phase1 = ({
                 onChange={(event) => handleInputChange(index, event, inputRefs)}
                 onKeyDown={(event) => handleBackspaceNavigation(index, event)}
                 maxLength="1"
-                className="w-full h-full max-w-20 sm:max-w-24 md:max-w-28 lg:max-w-32 aspect-square rounded-lg font-bold text-center text-2xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl bg-sp-white text-sp-black p-1"
+                className="w-full max-w-20 sm:max-w-24 md:max-w-28 lg:max-w-32 aspect-square rounded-lg font-bold text-center text-2xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl bg-sp-white text-sp-black p-1"
               />
             ))}
           </div>
-          <div className="flex items-end justify-center sm:justify-end  py-4">
+          <div className="flex items-end justify-center sm:justify-end  py-2">
             <button
               className={`btn-sp-primary w-full sm:w-1/2 ${
                 isReadyButtonDisabled

--- a/src/components/game/Phase2.js
+++ b/src/components/game/Phase2.js
@@ -38,7 +38,7 @@ const Phase2 = ({
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col">
       <h1 className="text-sp-white text-4xl md:text-6xl lg:text-7xl font-bold py-2 md:py-4">
         Järjestä kirjaimet
       </h1>
@@ -84,7 +84,7 @@ const Phase2 = ({
             </div>
           </div>
 
-          <div className="flex items-end justify-center sm:justify-end py-4">
+          <div className="flex items-end justify-center sm:justify-end py-5">
             <button
               className={`btn-sp-primary w-full sm:w-1/2 ${
                 isReadyButtonDisabled

--- a/src/components/game/Phase3.js
+++ b/src/components/game/Phase3.js
@@ -36,7 +36,7 @@ const Phase3 = ({
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col">
       <h1 className="text-sp-white text-4xl md:text-6xl lg:text-7xl font-bold py-2 md:py-4">
         Kopioi sana
       </h1>
@@ -81,7 +81,7 @@ const Phase3 = ({
             </div>
           </div>
 
-          <div className="flex items-end justify-center sm:justify-end py-4">
+          <div className="flex items-end justify-center sm:justify-end py-5">
             <button
               className={`btn-sp-primary w-full sm:w-1/2 ${
                 isReadyButtonDisabled


### PR DESCRIPTION
Tällä issuella parannettiin peli-näkymän skaalautuvuutta erityisesti ottan huomioon tabletit. Ensimmäisen kirjainlaatan automaattinen fokusointi poistettiin uuden sanan/vaiheen alkaessa. Näin tabletin vaaka-asennossa pelaaja näkee kaikki oleelliset komponentit ennen kuin näppäimistö nousee ylös. 'Valmis'-nappia siirrettiin hieman ylöspäin, jotta se näkyy pystyasennossa näppäimistön yläpuolella ja vakaa-asennossa se näkyy näytöllä silloin kuin näppäimistö on alhaalla. Lisäksi ImageContainer-komponenttia muokattiin niin, että sen sisällä oleva kuva on aina neliö eikä se veny omituisesti tabletin ollessa pystyasennossa.

ImageContainer.js komponentin kanssa on käytetty css-tyylejä tailwindin lisäksi, koska en osannut toteuttaa tälle komponentille eri kokoja riippuen siitä, onko laite vaaka- vai pystyasennossa käyttäen tailwindiä. Koitin opetella käyttämään tailwindiä paremmin, mutta en nyt säätänyt sen kanssa määräänsä enempää, jotta ei mene useampia tunteja vain siihen..En edes tiedä onnistuuko tämä pelkästään tailwindin avulla. Perehdyn sen käyttöön enemmän ensi viikolla, jos tämä on väliaikaisena ratkaisuna ok.