### PR TITLE
133 Scramble the word in phase 2 instead of true randomized

### DIFF
--- a/src/components/game/GameEngine.js
+++ b/src/components/game/GameEngine.js
@@ -115,6 +115,9 @@ const GameEngine = ({ pathName }) => {
       if (currentPhase === 1) {
         setCurrentPhase(2);
         setShuffledWord(shuffleWord(currentWord.word));
+        while (shuffledWord === currentWord.word) {
+          setShuffledWord(shuffleWord(currentWord.word));
+        }
       } else {
         setCurrentPhase(3);
       }


### PR DESCRIPTION
This pull request includes a small change to the `GameEngine` component in `src/components/game/GameEngine.js`. The change ensures that the shuffled word is different from the current word by adding a loop to reshuffle the word if it matches the original. We could do a more sophisticated approach but I doubt if that is actually necessary considering the users of the software.

* [`src/components/game/GameEngine.js`](diffhunk://#diff-a7d11390c7f24a3d865b688127c3a7260e9767a49196c060b8211e48737c7f70R118-R120): Added a loop to ensure the shuffled word is different from the current word.