### PR TITLE
150 pop up window for deleting a word

### DIFF
--- a/src/components/DeleteWordModal.js
+++ b/src/components/DeleteWordModal.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { deleteWord } from '../db/db';
+
+import PropTypes from 'prop-types';
+
+const DeleteWordModal = ({ onClose, wordId, setWords }) => {
+  const handleWordDelete = async () => {
+    try {
+      await deleteWord(wordId);
+      setWords((prevWords) => prevWords.filter((w) => w.id !== wordId));
+    } catch (error) {
+      console.error('Error deleting word:', error);
+      alert('Error deleting the word.');
+    }
+    onClose();
+  };
+
+  const closeDeleteModal = () => {
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <h2>Vahvista poisto</h2>
+        <p>Haluatko varmasti poistaa sanan?</p>
+        <div className="modal-buttons">
+          <button className="cancel-button" onClick={closeDeleteModal}>
+            Peruuta
+          </button>
+          <button className="save-button" onClick={handleWordDelete}>
+            Poista
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DeleteWordModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  wordId: PropTypes.number.isRequired,
+  setWords: PropTypes.func.isRequired,
+};
+
+export default DeleteWordModal;

--- a/src/components/DeleteWordModal.test.js
+++ b/src/components/DeleteWordModal.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import DeleteWordModal from './DeleteWordModal';
+import { deleteWord } from '../db/db';
+
+jest.mock('../db/db');
+
+describe('DeleteWordModal', () => {
+  const mockOnClose = jest.fn();
+  const mockSetWords = jest.fn();
+  const wordId = 1;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders correctly', () => {
+    const { getByText } = render(
+      <DeleteWordModal
+        onClose={mockOnClose}
+        wordId={wordId}
+        setWords={mockSetWords}
+      />
+    );
+
+    expect(getByText('Vahvista poisto')).toBeInTheDocument();
+    expect(getByText('Haluatko varmasti poistaa sanan?')).toBeInTheDocument();
+    expect(getByText('Peruuta')).toBeInTheDocument();
+    expect(getByText('Poista')).toBeInTheDocument();
+  });
+
+  test('calls onClose when cancel button is clicked', () => {
+    const { getByText } = render(
+      <DeleteWordModal
+        onClose={mockOnClose}
+        wordId={wordId}
+        setWords={mockSetWords}
+      />
+    );
+
+    fireEvent.click(getByText('Peruuta'));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  test('calls deleteWord and setWords when delete button is clicked', async () => {
+    deleteWord.mockResolvedValueOnce();
+
+    const { getByText } = render(
+      <DeleteWordModal
+        onClose={mockOnClose}
+        wordId={wordId}
+        setWords={mockSetWords}
+      />
+    );
+
+    fireEvent.click(getByText('Poista'));
+
+    await waitFor(() => {
+      expect(deleteWord).toHaveBeenCalledWith(wordId);
+      expect(mockSetWords).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  test('shows alert and logs error if deleteWord fails', async () => {
+    const errorMessage = 'Error deleting word';
+    deleteWord.mockRejectedValueOnce(new Error(errorMessage));
+    window.alert = jest.fn();
+
+    const { getByText } = render(
+      <DeleteWordModal
+        onClose={mockOnClose}
+        wordId={wordId}
+        setWords={mockSetWords}
+      />
+    );
+
+    fireEvent.click(getByText('Poista'));
+
+    await waitFor(() => {
+      expect(deleteWord).toHaveBeenCalledWith(wordId);
+      expect(window.alert).toHaveBeenCalledWith('Error deleting the word.');
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/pages/ManagePath.js
+++ b/src/pages/ManagePath.js
@@ -1,13 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  getWordsForPath,
-  deleteWord,
-  getPathById,
-  editPathName,
-} from '../db/db';
+import { getWordsForPath, getPathById, editPathName } from '../db/db';
 import WordRow from '../components/create/WordRow';
 import BackButton from '../components/universal/BackButton';
+import DeleteWordModal from '../components/DeleteWordModal'; // Import the DeleteWordModal component
 import '../styles/ManagePath.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
@@ -20,8 +16,9 @@ const ManagePath = () => {
   const [words, setWords] = useState([]);
   const [error, setError] = useState(null);
   const [newPathName, setNewPathName] = useState('');
-
   const [isEditPathNameModalOpen, setIsEditPathNameModalOpen] = useState(false);
+  const [isDeleteWordModalOpen, setIsDeleteWordModalOpen] = useState(false); // State to control the DeleteWordModal
+  const [wordToDelete, setWordToDelete] = useState(null); // State to store the word to be deleted
 
   // Function to fetch words for the path when the component loads
   useEffect(() => {
@@ -39,19 +36,6 @@ const ManagePath = () => {
     };
     fetchData();
   }, [pathId]);
-
-  // Function to delete a word from the database and update the word list
-  const handleDelete = (wordId) => {
-    deleteWord(wordId)
-      .then(() => {
-        setWords((prevWords) => prevWords.filter((word) => word.id !== wordId));
-        console.log(`Deleted word with id: ${wordId}`);
-      })
-      .catch((error) => {
-        console.error('Error deleting word:', error);
-        alert('Error deleting the word.');
-      });
-  };
 
   const handleEditPathNameClick = () => {
     if (newPathName.trim()) {
@@ -77,6 +61,16 @@ const ManagePath = () => {
 
   const closeEditPathNameModal = () => {
     setIsEditPathNameModalOpen(false);
+  };
+
+  const openDeleteWordModal = (wordId) => {
+    setWordToDelete(wordId);
+    setIsDeleteWordModalOpen(true);
+  };
+
+  const closeDeleteWordModal = () => {
+    setIsDeleteWordModalOpen(false);
+    setWordToDelete(null);
   };
 
   return (
@@ -109,7 +103,7 @@ const ManagePath = () => {
                 key={index}
                 word={wordEntry.word}
                 imgSrc={wordEntry.imageData.src}
-                onDelete={() => handleDelete(wordEntry.id)}
+                onDelete={() => openDeleteWordModal(wordEntry.id)} // Open the delete modal
               />
             ))
           ) : (
@@ -141,6 +135,13 @@ const ManagePath = () => {
             </div>
           </div>
         </div>
+      )}
+      {isDeleteWordModalOpen && (
+        <DeleteWordModal
+          onClose={closeDeleteWordModal}
+          wordId={wordToDelete}
+          setWords={setWords} // Pass the setWords function as a prop
+        />
       )}
     </div>
   );

--- a/src/pages/ManagePath.test.js
+++ b/src/pages/ManagePath.test.js
@@ -186,4 +186,68 @@ describe('ManagePath Component UI Tests', () => {
       expect(window.alert).toHaveBeenCalledWith('Failed to edit path name');
     });
   });
+
+  it('adds a word and then deletes it', async () => {
+    // Mock the addWord function
+    const mockAddWord = jest.spyOn(db, 'addWord');
+    mockAddWord.mockResolvedValue({
+      id: 1,
+      word: 'Test Word',
+      imageData: { src: 'test-image-src' },
+    });
+
+    // Mock the getWordsForPath function to return the added word
+    const mockGetWordsForPath = jest.spyOn(db, 'getWordsForPath');
+    mockGetWordsForPath.mockResolvedValue([
+      {
+        id: 1,
+        word: 'Test Word',
+        imageData: { src: 'test-image-src' },
+      },
+    ]);
+
+    const { container } = render(
+      <BrowserRouter>
+        <ManagePath />
+      </BrowserRouter>
+    );
+
+    // Simulate adding a word
+    fireEvent.click(screen.getByLabelText('Lisää uusi sana'));
+    expect(mockNavigate).toHaveBeenCalledWith(`/uusisana/${pathId}`);
+
+    // Mock the navigate function to simulate returning to the ManagePath view
+    mockNavigate.mockImplementation(() => {
+      render(
+        <BrowserRouter>
+          <ManagePath />
+        </BrowserRouter>
+      );
+    });
+
+    // Wait for the word to be displayed in the list
+    await waitFor(() => {
+      expect(screen.getByText('Test Word')).toBeInTheDocument();
+    });
+
+    // Simulate opening the delete word modal
+    const deleteButton = container.querySelector('.delete-button');
+    expect(deleteButton).toBeInTheDocument();
+    fireEvent.click(deleteButton);
+    expect(
+      screen.getByText(/Haluatko varmasti poistaa sanan?/i)
+    ).toBeInTheDocument();
+
+    // Mock the deleteWord function
+    const mockDeleteWord = jest.spyOn(db, 'deleteWord');
+    mockDeleteWord.mockResolvedValue();
+
+    // Simulate confirming the deletion
+    fireEvent.click(screen.getByRole('button', { name: /Poista/i }));
+
+    // Wait for the word to be removed from the list
+    await waitFor(() => {
+      expect(screen.queryByText('Test Word')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
This pull request introduces a new `DeleteWordModal` component and integrates it into the `ManagePath` page. It also includes corresponding tests for the new modal and updates the existing tests for the `ManagePath` component.

### New Component Addition:
* [`src/components/DeleteWordModal.js`](diffhunk://#diff-d7e9555fa9314e09721a19511b6b0ec3f813c1d5a3172aea6a69ab948c6b879aR1-R46): Added a new modal component for confirming word deletions, which includes functions for handling word deletion and closing the modal.
* [`src/components/DeleteWordModal.test.js`](diffhunk://#diff-4003178500fe0a9b2eaf4abc033eaf23cd9f69bc727bc80860d4e0405246065bR1-R86): Added tests for the `DeleteWordModal` component, ensuring it renders correctly and handles delete and cancel actions properly.

### Integration into `ManagePath` Page:
* [`src/pages/ManagePath.js`](diffhunk://#diff-588f83ceb40b63a7754693d8e57ac287d3c243fe1332c542b4c2d75ccf09fe3bL3-R6): Integrated `DeleteWordModal` into the `ManagePath` page by adding state management for the modal and updating the word deletion logic to use the modal.
* [`src/pages/ManagePath.test.js`](diffhunk://#diff-c6ddd8279e57f0ca68f8fa6f17fdeb9c0ff472fbbfee986acb01badbbd60f01aR189-R252): Updated tests for the `ManagePath` component to include scenarios for adding and deleting words using the new modal.

Closes #150