### PR TITLE
161 implement path like progress bar to the game

### DIFF
--- a/src/components/game/GameEngine.css
+++ b/src/components/game/GameEngine.css
@@ -15,13 +15,29 @@ h2 {
     font-size: var(--sp-heading-1);
 }
 
+.top-bar {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    justify-content: space-between;
+    margin-bottom: 25px;
+    padding-top: 11px;
+    padding-left: 9px;
+}
+
+.progress-bar-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%
+}
+
 .game-back-button {
     display: flex;
     align-items: center;
     width: 100%;
     position: absolute;
-    top: 25px;
-    left: 25px;
     grid-area: back-button;
     width: 100px;
 }

--- a/src/components/game/GameEngine.js
+++ b/src/components/game/GameEngine.js
@@ -7,6 +7,7 @@ import SuccessIndicator from './SuccessIndicator';
 import './GameEngine.css';
 import PhaseController from './PhaseController';
 import BackButton from '../universal/BackButton';
+import ProgressBar from './ProgressBar';
 
 const GameEngine = ({ pathId }) => {
   const [words, setWords] = useState([]);
@@ -19,6 +20,7 @@ const GameEngine = ({ pathId }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showSuccess, setShowSuccess] = useState(false);
+  const [progress, setProgress] = useState(0);
   const inputRefs = useRef([]);
 
   useEffect(() => {
@@ -126,8 +128,10 @@ const GameEngine = ({ pathId }) => {
 
     if (wordIndex + 1 < words.length) {
       setWordIndex(wordIndex + 1);
+      setProgress((prevProgress) => prevProgress + 100 / words.length);
     } else {
       setGameOver(true);
+      setProgress(100);
     }
   };
 
@@ -143,8 +147,11 @@ const GameEngine = ({ pathId }) => {
 
   return (
     <div className="flex flex-col  h-screen p-2 pb-10 sm:p-2 md:p-4">
-      <div className="px-2">
+      <div className="top-bar">
         <BackButton />
+        <div className="progress-bar-container">
+          <ProgressBar progress={progress} />
+        </div>
       </div>
       <div className="flex-grow">
         {loading ? (

--- a/src/components/game/GameEngine.test.js
+++ b/src/components/game/GameEngine.test.js
@@ -218,6 +218,98 @@ describe('GameEngine Component with IndexedDB', () => {
     expect(progressBar).toBeInTheDocument();
   });
 
+  it('checks that the initial progress is 0%', async () => {
+    render(
+      <MemoryRouter>
+        <GameEngine pathId={String(pathId)} />
+      </MemoryRouter>
+    );
+
+    const progressBar = screen.getByTestId('progress-bar');
+    const progress = progressBar.querySelector('.progress');
+    expect(progress).toHaveStyle(`width: ${0}%`);
+  });
+
+  it('check that progress is 100% when game is over', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <MemoryRouter>
+        <GameEngine pathId={String(pathId)} />
+      </MemoryRouter>
+    );
+
+    // Wait that game begins
+    await waitFor(() => screen.getByText('Kirjoita sana'));
+
+    for (let i = 0; i < 10; i++) {
+      // Wait for the word and its image to be displayed
+      const image = await screen.findByRole('img');
+      const imageSrc = image.getAttribute('src');
+
+      // Use the first image's src to figure out what is correct word
+      const correctWord = imageSrc.replace('.jpg', '');
+
+      // Enter the correct word for the first phase
+      correctWord.split('').forEach((letter, index) => {
+        fireEvent.change(screen.getAllByRole('textbox')[index], {
+          target: { value: letter },
+        });
+      });
+      fireEvent.click(screen.getByText('VALMIS'));
+
+      act(() => {
+        jest.advanceTimersByTime(2500);
+      });
+    }
+
+    const progressBar = screen.getByTestId('progress-bar');
+    const progress = progressBar.querySelector('.progress');
+    expect(progress).toHaveStyle(`width: ${100}%`);
+
+    jest.useRealTimers();
+  });
+
+  it('check that progress is 50% when game is half-way done', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <MemoryRouter>
+        <GameEngine pathId={String(pathId)} />
+      </MemoryRouter>
+    );
+
+    // Wait that game begins
+    await waitFor(() => screen.getByText('Kirjoita sana'));
+
+    for (let i = 0; i < 5; i++) {
+      // Wait for the word and its image to be displayed
+      const image = await screen.findByRole('img');
+      const imageSrc = image.getAttribute('src');
+
+      // Use the first image's src to figure out what is correct word
+      const correctWord = imageSrc.replace('.jpg', '');
+
+      // Enter the correct word for the first phase
+      correctWord.split('').forEach((letter, index) => {
+        fireEvent.change(screen.getAllByRole('textbox')[index], {
+          target: { value: letter },
+        });
+      });
+      fireEvent.click(screen.getByText('VALMIS'));
+
+      act(() => {
+        jest.advanceTimersByTime(2500);
+      });
+    }
+
+    const progressBar = screen.getByTestId('progress-bar');
+    const progress = progressBar.querySelector('.progress');
+    expect(progress).toHaveStyle(`width: ${50}%`);
+
+    jest.useRealTimers();
+  });
+
   it('checks that the back-button brings you to /omatpolut', () => {
     // Rendering the required pages
     const { container } = render(

--- a/src/components/game/GameEngine.test.js
+++ b/src/components/game/GameEngine.test.js
@@ -206,6 +206,18 @@ describe('GameEngine Component with IndexedDB', () => {
     expect(screen.queryByTestId('success-indicator')).toBeNull();
   });
 
+  it('checks that the progress-bar renders on game page', async () => {
+    render(
+      <MemoryRouter>
+        <GameEngine pathId={String(pathId)} />
+      </MemoryRouter>
+    );
+
+    // Check that the progress bar is in the document
+    const progressBar = screen.getByTestId('progress-bar');
+    expect(progressBar).toBeInTheDocument();
+  });
+
   it('checks that the back-button brings you to /omatpolut', () => {
     // Rendering the required pages
     const { container } = render(

--- a/src/components/game/ProgressBar.js
+++ b/src/components/game/ProgressBar.js
@@ -1,0 +1,18 @@
+// src/components/ProgressBar.js
+import React from 'react';
+import PropTypes from 'prop-types';
+import '../../styles/ProgressBar.css';
+
+const ProgressBar = ({ progress }) => {
+  return (
+    <div className="progress-bar">
+      <div className="progress" style={{ width: `${progress}%` }}></div>
+    </div>
+  );
+};
+
+ProgressBar.propTypes = {
+  progress: PropTypes.number.isRequired,
+};
+
+export default ProgressBar;

--- a/src/components/game/ProgressBar.js
+++ b/src/components/game/ProgressBar.js
@@ -5,7 +5,7 @@ import '../../styles/ProgressBar.css';
 
 const ProgressBar = ({ progress }) => {
   return (
-    <div className="progress-bar">
+    <div className="progress-bar" data-testid="progress-bar">
       <div className="progress" style={{ width: `${progress}%` }}></div>
     </div>
   );

--- a/src/styles/ProgressBar.css
+++ b/src/styles/ProgressBar.css
@@ -1,0 +1,17 @@
+/* src/components/ProgressBar.css */
+.progress-bar {
+    display: flex;
+    height: 60%;
+    width: 85%;
+    background-color:#F0D784;
+    border-radius: 35px;
+    align-items: center;
+    padding: 0 1vw;
+}
+  
+.progress {
+    height: 60%;
+    background-color: #B38D2E;
+    transition: width 0.3s ease;
+    border-radius: 25px;
+}


### PR DESCRIPTION
Tällä issuella toteutettiin UI-suunnitelman mukainen progress bar -komponentti. Tämä komponentti lisättiin peli-sivulle niin, että aina vaihdettaessa uuteen sanaan edistyminen kasvaa progress barilla. Progress bar skaalautuu kivasti ja sille on toteutettu yksikkötestit. Peli-sivulla testataan, että progress bar -komponentti renderöityy sivulle ja lisäksi progress barin näyttämää edistysastetta testataan varmistaen, että se on pelin alussa 0%, puolivälissä 50% ja pelin lopussa 100%. 

Closes #161 