### PR TITLE
233 larger preview for cropped images

### DIFF
--- a/src/components/ImagePreview.css
+++ b/src/components/ImagePreview.css
@@ -19,24 +19,27 @@
   background-color: var(--sp-white);
   border-radius: 8px;
   width: 90%;
+  height: 90%;
   padding: 20px;
   text-align: center;
   overflow: hidden;
 }
 
 .enlarged-image {
-  max-width: 100%;
-  max-height: 60vh;
-  margin: 0 auto;
-  display: block;
+  height: 90% !important;
   object-fit: contain;
+  image-rendering: auto;
+  margin: 0 auto;
 }
 
 .image-author {
-  margin-top: 1rem;
+  margin-top: 20px;
   font-size: 1rem;
-  text-align: center;
   word-wrap: break-word;
+  height: 1rem;
+  line-height: 1rem;
+  background-color: var(--sp-white);
+  flex-shrink: 0;
 }
 
 .close-btn {
@@ -60,17 +63,20 @@
   margin-left: 10px;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 400px) {
+  .enlarged-image {
+    width: 90% !important;
+    height: auto;
+  }
+}
+
+@media (min-width: 401px) {
   .image-preview-container {
     width: 95%;
-    padding: 15px;
   }
 
   .enlarged-image {
-    max-height: 50vh;
-  }
-
-  .image-author {
-    font-size: 1 rem;
+    width: 90% !important;
+    height: auto;
   }
 }

--- a/src/components/ImagePreview.css
+++ b/src/components/ImagePreview.css
@@ -35,7 +35,6 @@
 .image-author {
   margin-top: 20px;
   font-size: 1rem;
-  word-wrap: break-word;
   height: 1rem;
   line-height: 1rem;
   background-color: var(--sp-white);
@@ -64,17 +63,18 @@
 }
 
 @media (max-width: 400px) {
+  .image-preview-container {
+    height: 95%;
+  }
+
   .enlarged-image {
     width: 90% !important;
     height: auto;
+    max-height: 80%;
   }
 }
 
 @media (min-width: 401px) {
-  .image-preview-container {
-    width: 95%;
-  }
-
   .enlarged-image {
     width: 90% !important;
     height: auto;

--- a/src/components/ImagePreview.css
+++ b/src/components/ImagePreview.css
@@ -29,6 +29,7 @@
   max-height: 60vh;
   margin: 0 auto;
   display: block;
+  object-fit: contain;
 }
 
 .image-author {


### PR DESCRIPTION
Fiksattu ImagePreviewiä niin, että kuvia oikeasti suurennetaan, jos on tilaa. Aikaisemmin ne pysyivät herkästi originaalin kokoisina. Kuvat säilyttävät myös alkuperäiset suhteensa. Toteutuksessa on käytetty !important, mikä ei ole optimaallisinta, mutta muuten en pystynyt vaikuttamaan kuvan kokoon ollenkaan...mistä lie johtuu mut ei kyl kiinnostakkaan. (: