### PR TITLE
299 fix image cropper with long photos

### DIFF
--- a/src/components/newWord/ImageCropper.js
+++ b/src/components/newWord/ImageCropper.js
@@ -53,18 +53,20 @@ const ImageCropper = ({
               ref={cropperRef}
             />
           </div>
-          <button
-            onClick={handleBack}
-            className="absolute top-4 left-4 bg-gray-300 text-black py-1 px-3 rounded hover:bg-gray-400 transition"
-          >
-            Takaisin
-          </button>
-          <button
-            onClick={handleCrop}
-            className="absolute bottom-2 sm:bottom-1 left-1/2 transform -translate-x-1/2 bg-sp-dark-green text-white py-2 px-4 sm:py-0.5 rounded"
-          >
-            Rajaa
-          </button>
+          <div className="absolute bottom-2 sm:bottom-1 left-1/2 transform -translate-x-1/2 flex gap-4 justify-center items-center">
+            <button
+              onClick={handleBack}
+              className="bg-sp-red text-white py-2 px-4 sm:py-0.5 rounded"
+            >
+              Takaisin
+            </button>
+            <button
+              onClick={handleCrop}
+              className="bg-sp-dark-green text-white py-2 px-4 sm:py-0.5 rounded"
+            >
+              Rajaa
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/newWord/ImageCropper.js
+++ b/src/components/newWord/ImageCropper.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import { Cropper } from 'react-cropper';
 import 'cropperjs/dist/cropper.css';
 
-const ImageCropper = ({ imageSrc, onCroppedImage }) => {
+const ImageCropper = ({
+  imageSrc,
+  onCroppedImage,
+  onBack,
+  imageSource,
+  reopenFileSelector,
+}) => {
   const cropperRef = useRef(null);
 
   const handleCrop = () => {
@@ -16,6 +22,13 @@ const ImageCropper = ({ imageSrc, onCroppedImage }) => {
     });
 
     onCroppedImage(croppedCanvas.toDataURL('image/png'));
+  };
+
+  const handleBack = () => {
+    if (imageSource === 'device') {
+      reopenFileSelector();
+    }
+    onBack();
   };
 
   return (
@@ -41,6 +54,12 @@ const ImageCropper = ({ imageSrc, onCroppedImage }) => {
             />
           </div>
           <button
+            onClick={handleBack}
+            className="absolute top-4 left-4 bg-gray-300 text-black py-1 px-3 rounded hover:bg-gray-400 transition"
+          >
+            Takaisin
+          </button>
+          <button
             onClick={handleCrop}
             className="absolute bottom-2 sm:bottom-1 left-1/2 transform -translate-x-1/2 bg-sp-dark-green text-white py-2 px-4 sm:py-0.5 rounded"
           >
@@ -55,6 +74,9 @@ const ImageCropper = ({ imageSrc, onCroppedImage }) => {
 ImageCropper.propTypes = {
   imageSrc: PropTypes.string.isRequired,
   onCroppedImage: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+  imageSource: PropTypes.string,
+  reopenFileSelector: PropTypes.func,
 };
 
 export default ImageCropper;

--- a/src/components/newWord/ImageCropper.js
+++ b/src/components/newWord/ImageCropper.js
@@ -11,8 +11,8 @@ const ImageCropper = ({ imageSrc, onCroppedImage }) => {
 
     const cropper = cropperRef.current.cropper;
     const croppedCanvas = cropper.getCroppedCanvas({
-      maxWidth: 400,
-      maxHeight: 400,
+      maxWidth: 600,
+      maxHeight: 600,
     });
 
     onCroppedImage(croppedCanvas.toDataURL('image/png'));
@@ -36,7 +36,7 @@ const ImageCropper = ({ imageSrc, onCroppedImage }) => {
               cropBoxResizable={false}
               cropBoxMovable={true}
               dragMode="none"
-              viewMode={1}
+              viewMode={0}
               ref={cropperRef}
             />
           </div>

--- a/src/components/newWord/ImageUploader.js
+++ b/src/components/newWord/ImageUploader.js
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import '../../styles/NewWord.css';
 import { faTabletScreenButton } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 // Component that allows uploading images
-const ImageUploader = ({ setImageData }) => {
-  const handleFileUpload = async (event) => {
+const ImageUploader = ({ setImageData, setImageSource }) => {
+  const [imageKey, setImageKey] = useState(0);
+
+  const handleFileUpload = (event) => {
     const file = event.target.files[0];
     if (!file) return;
 
@@ -20,6 +22,8 @@ const ImageUploader = ({ setImageData }) => {
     const reader = new FileReader();
     reader.onload = async (e) => {
       setImageData({ src: e.target.result, author: null });
+      setImageSource('device');
+      setImageKey((prevKey) => prevKey + 1);
     };
     reader.readAsDataURL(file);
   };
@@ -40,6 +44,7 @@ const ImageUploader = ({ setImageData }) => {
         onChange={handleFileUpload}
         style={{ display: 'none' }}
         id="hiddenFileInput"
+        key={imageKey}
       />
     </div>
   );
@@ -47,6 +52,7 @@ const ImageUploader = ({ setImageData }) => {
 
 ImageUploader.propTypes = {
   setImageData: PropTypes.func,
+  setImageSource: PropTypes.func,
 };
 
 export default ImageUploader;

--- a/src/pages/NewWord.js
+++ b/src/pages/NewWord.js
@@ -21,6 +21,7 @@ const NewWord = () => {
   );
   const [isPapunetOpen, setIsPapunetOpen] = useState(false);
   const [isCropping, setIsCropping] = useState(false);
+  const [imageSource, setImageSource] = useState(null);
   const [isLargeImgPreviewOpen, setIsLargeImgPreviewOpen] = useState(false);
   const [largeImgPreview, setLargeImgPreview] = useState(null);
 
@@ -59,18 +60,23 @@ const NewWord = () => {
     setIsPapunetOpen(false); // Close Papunet modal as well
   };
 
-  const handleImageSelection = (image) => {
+  const handleImageSelection = (image, source) => {
     // Set the selected image and author from Papunet
     setImageData({
       src: image.src,
       author: image.author,
     });
+    setImageSource(source);
     setIsCropping(true); // Open the cropping modal
   };
 
   const handleLargeImgPreview = (image) => {
     setLargeImgPreview(image);
     setIsLargeImgPreviewOpen(true);
+  };
+
+  const reopenFileSelector = () => {
+    document.getElementById('hiddenFileInput').click();
   };
 
   return (
@@ -97,7 +103,10 @@ const NewWord = () => {
           <div className="img-upload-container">
             <label>Lataa kuva</label>
             <div className="img-upload-button-container">
-              <ImageUploader setImageData={handleImageSelection} />
+              <ImageUploader
+                setImageData={handleImageSelection}
+                setImageSource={setImageSource}
+              />
               <button
                 className="img-upload-button"
                 onClick={() => setIsPapunetOpen(true)}
@@ -150,8 +159,12 @@ const NewWord = () => {
       <Modal isOpen={isCropping} modalType="image-cropper">
         {imageData && (
           <ImageCropper
-            imageSrc={imageData?.src}
+            key={imageData.src}
+            imageSrc={imageData.src}
             onCroppedImage={handleImageCrop}
+            onBack={() => setIsCropping(false)}
+            imageSource={imageSource}
+            reopenFileSelector={reopenFileSelector}
           />
         )}
       </Modal>


### PR DESCRIPTION
Tässä issuessa oli tarkoitus poistaa kuvan rajauksesta rajoitteet zoomaamiselle, jotta suuriakin kuvia voi zoomata riittävän pieneksi, saadakseen ne halutessaa mahtumaan rajausneliön sisälle. Toteutin tuon sekä nostin kuvien tallennuskokoa 400x400 -> 600x600, jotta resoluutio olisi alkuperäisesti suurienkin kuvien kohdalla riittävä.

Toteutin samalla takaisin napin kuvien rajaukseen, joka mahdollistaa kuvan vaihtamisen toiseen vielä rajausnäkymässäkin. Closes #299