### PR TITLE
250 polun valinta valikon tyyliongelmat

### DIFF
--- a/src/styles/GameMenu.css
+++ b/src/styles/GameMenu.css
@@ -118,33 +118,4 @@
     margin-right: 10px;
   }
 
-  .path-button {
-    height: 60px;
-    margin-bottom: 10px;
-  }
-}
-
-/* Style for extremely narrow screens in portrait mode */
-@media (max-width: 360px) {
-  .path-button {
-    width: 95vw;
-    line-height: normal;
-  }
-}
-
-/* Style for the narrowest possible screens in portrait mode */
-@media (max-width: 200px) {
-  .path-button {
-    width: 95vw;
-    line-height: normal;
-  }
-}
-
-/* Style for extremely narrow screens in Horizontal mode */
-@media (max-height: 360px) {
-  .path-button {
-    height: 15vh;
-    line-height: normal;
-    margin-bottom: 10px;
-  }
 }

--- a/src/styles/PathSelection.css
+++ b/src/styles/PathSelection.css
@@ -180,9 +180,6 @@
     margin-bottom: 300px;
   }
 
-  .path-list {
-    height: 60vh;
-  }
 }
 
 /* Style for phones in horizontal mode */
@@ -191,8 +188,5 @@
     background-image: none;
   }
 
-  .path-list {
-    height: 60vh;
-  }
 }
 


### PR DESCRIPTION
Tällä issuella korjattiin uuden taustan lisäämisessä ilmennyt bugi. Mobiililaitteille oli jäänyt polun valinta -valikkoon (PathSelection) ylimääräisiä tyylejä, joiden takia valikot eivät näyttäneet yhtenäisiltä keskenään. Polun valinta -valikon alareunaan jäi nyt mobiililaitteella ylimääräistä tyhjää tilaa leikaten taustakuvion omituisesti. Tämä ongelma korjattiin muutoin jo aiemmin, mutta nämä tyylit olivat vielä jääneet tähän yhteen valikkoon mobiililaittelle. Nyt ylimääräiset tyylit poistettiin. Lisäksi tässä yhteydessä poistettiin ylimääräiset tyylit peli-valikosta (GameMenu). Nämä poistettiin, koska tyylejä ei käytetty muissa valikoissa. Näin valikot näyttävät nyt keskenään aina samanlaiselta myös mobiililaitteilla:
![Screenshot_20241126_090948_Chrome](https://github.com/user-attachments/assets/f2a41796-106c-4e92-acc8-028787d39f25)
![Screenshot_20241126_090953_Chrome](https://github.com/user-attachments/assets/cc45a02d-e615-4d79-a4ef-a6ad53f0040f)
![Screenshot_20241126_090957_Chrome](https://github.com/user-attachments/assets/1caa7086-ce62-4f2c-a684-191540a48a98)

Closes #250 