### PR TITLE
222 papunet UI fixes

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -45,6 +45,11 @@
   max-height: none;
 }
 
+.modal-overlay[data-modal-type='papunet'] .modal-content {
+  width: 95vw;
+  height: 95vh;
+}
+
 @media (max-width: 767px) and (max-height: 270px) {
   .modal-overlay[data-modal-type='image-cropper'] .modal-content {
     top: 70%;

--- a/src/components/newWord/PapunetFilterMenu.css
+++ b/src/components/newWord/PapunetFilterMenu.css
@@ -1,6 +1,6 @@
 .filter-menu {
   margin-bottom: 20px;
-  padding: 20px;
+  padding: 10px;
   border: 1px solid var(--sp-gray-sp);
   border-radius: 10px;
   width: 100%;

--- a/src/components/newWord/PapunetFilterMenu.css
+++ b/src/components/newWord/PapunetFilterMenu.css
@@ -39,7 +39,6 @@ h3 {
 .filter-options-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
   justify-content: space-between;
 }
 
@@ -54,7 +53,7 @@ h3 {
   box-sizing: border-box;
 }
 
-.filter-option label {
+.filter-label {
   font-size: var(--sp-heading-6);
   font-weight: bold;
   color: var(--sp-black);

--- a/src/components/newWord/PapunetFilterMenu.js
+++ b/src/components/newWord/PapunetFilterMenu.js
@@ -19,11 +19,6 @@ const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
     }
   };
 
-  // Toggle the checkbox when clicking the filter option div
-  const handleFilterOptionClick = (filterKey) => {
-    handleCheckboxChange(filterKey);
-  };
-
   const handleUnselectAll = () => {
     onFilterChange([]);
   };
@@ -47,24 +42,20 @@ const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
 
           <div className="filter-options-container">
             {Object.entries(filters).map(([key, label]) => (
-              <div
-                key={key}
-                className="filter-option"
-                onClick={() => handleFilterOptionClick(key)}
-              >
+              <label key={key} htmlFor={key} className="filter-option">
                 <input
                   type="checkbox"
                   id={key}
                   checked={selectedFilters.includes(key)}
                   onChange={() => handleCheckboxChange(key)}
                 />
-                <label htmlFor={key}>{label}</label>
+                <span className="filter-label">{label}</span>
                 <img
                   src={public_url + `/papunet-img-types/${key}.png`}
                   alt={label}
                   className="filter-icon"
                 />
-              </div>
+              </label>
             ))}
           </div>
         </div>

--- a/src/pages/NewWord.js
+++ b/src/pages/NewWord.js
@@ -139,7 +139,11 @@ const NewWord = () => {
       </div>
 
       {/* Modal for PapunetView */}
-      <Modal isOpen={isPapunetOpen} onClose={() => setIsPapunetOpen(false)}>
+      <Modal
+        isOpen={isPapunetOpen}
+        modalType="papunet"
+        onClose={() => setIsPapunetOpen(false)}
+      >
         <PapunetView
           onSelectImage={handleImageSelection}
           initialSearchTerm={newWord}

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -99,10 +99,10 @@
 
 .return-save-button-container {
   position: fixed;
-  bottom: 5%;
+  bottom: 5vh;
   left: 50%;
   transform: translateX(-50%);
-  width: 80%;
+  width: 90vw;
   padding: 10px;
   background-color: var(--sp-white);
   display: flex;
@@ -135,10 +135,6 @@
   .photo-fetcher input,
   .search-button {
     width: 100%;
-  }
-
-  .return-save-button-container {
-    bottom: 20%;
   }
 
   .return-save-button-container button {

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -28,7 +28,7 @@
   padding: 10px 20px;
   background-color: var(--sp-light-green);
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   color: var(--sp-white);
   font-size: var(--sp-heading-6);
   font-weight: bold;

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -144,6 +144,7 @@
   .return-save-button-container button {
     width: 40%;
     height: 10%;
+    font-size: calc(var(--sp-heading-5) - 4px);
   }
 
   .photo-container {

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -30,8 +30,8 @@
   border: none;
   border-radius: 4px;
   color: var(--sp-white);
-  font-size: 1rem;
   font-size: var(--sp-heading-6);
+  font-weight: bold;
 }
 
 .search-button:disabled {


### PR DESCRIPTION
Yeet yeet Papunet on taas hieman kauniimpi:
- helpompi käyttää kapeammalla ruudulla
- filttereitä voi (jälleen?) valita klikkaamalla koko "korttia" checkboxin sijaan

Alalaidan napit loksahtavat kapealla ruudulla paikoilleen, kunhan modaalit saadaan korjattua.