### PR TITLE
131 Better pwa downloading

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,6 @@
 {
   "short_name": "Sanapolku",
   "name": "Sanapolku",
-  "description": "Lähdekoodi saatavilla: https://github.com/koodikilpparit/sanapolku",
   "icons": [
     {
       "src": "/sanapolku/icons/Logo48x48.png",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { HashRouter as Router, Route, Routes } from 'react-router-dom';
 import './App.css';
 import Start from './pages/Start';
@@ -11,8 +11,27 @@ import NewWord from './pages/NewWord';
 import GamePage from './pages/GamePage';
 import { PathProvider } from './components/pathSelection/PathContext';
 import BackgroundMusic from './components/sounds/BackgroundMusic';
+import { SettingsContext } from './contexts/SettingsContext';
 
 function App() {
+  const { setInstallEvent } = useContext(SettingsContext);
+
+  useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      setInstallEvent(e);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('appinstalled', () => {
+      setInstallEvent(null);
+    });
+  }, []);
+
   return (
     <Router>
       <div className="App">

--- a/src/App.js
+++ b/src/App.js
@@ -24,13 +24,13 @@ function App() {
     window.addEventListener('beforeinstallprompt', handler);
 
     return () => window.removeEventListener('beforeinstallprompt', handler);
-  }, []);
+  }, [setInstallEvent]);
 
   useEffect(() => {
     window.addEventListener('appinstalled', () => {
       setInstallEvent(null);
     });
-  }, []);
+  }, [setInstallEvent]);
 
   return (
     <Router>

--- a/src/components/start/InstallButton.js
+++ b/src/components/start/InstallButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCircleDown } from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types';
+
+function InstallButton({ onClick }) {
+  return (
+    <button className="settings-button" onClick={onClick}>
+      <FontAwesomeIcon
+        icon={faCircleDown}
+        color="white"
+        className="settings-icon"
+      />
+    </button>
+  );
+}
+
+InstallButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+export default InstallButton;

--- a/src/components/start/LetterTile.js
+++ b/src/components/start/LetterTile.js
@@ -1,4 +1,3 @@
-// src/components/start/LetterTile.js
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/src/components/start/SettingsButton.js
+++ b/src/components/start/SettingsButton.js
@@ -1,4 +1,3 @@
-// src/components/start/SettingsButton.js
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/src/contexts/SettingsContext.js
+++ b/src/contexts/SettingsContext.js
@@ -23,6 +23,8 @@ export const SettingsProvider = ({ children }) => {
     return savedMusic !== null ? JSON.parse(savedMusic) : true;
   });
 
+  const [installEvent, setInstallEvent] = useState(null);
+
   useEffect(() => {
     localStorage.setItem('sounds', JSON.stringify(sounds));
   }, [sounds]);
@@ -32,7 +34,16 @@ export const SettingsProvider = ({ children }) => {
   }, [music]);
 
   return (
-    <SettingsContext.Provider value={{ sounds, setSounds, music, setMusic }}>
+    <SettingsContext.Provider
+      value={{
+        sounds,
+        setSounds,
+        music,
+        setMusic,
+        installEvent,
+        setInstallEvent,
+      }}
+    >
       {children}
     </SettingsContext.Provider>
   );

--- a/src/pages/Instructions.test.js
+++ b/src/pages/Instructions.test.js
@@ -3,12 +3,15 @@ import { render, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import Start from './Start';
 import Instructions from './Instructions';
+import SettingsProvider from '../contexts/SettingsContext';
 
 describe('StartPage', () => {
   it('checks if Instructions-page renders', () => {
     const { getByText, getByAltText } = render(
       <BrowserRouter>
-        <Instructions />
+        <SettingsProvider>
+          <Instructions />
+        </SettingsProvider>
       </BrowserRouter>
     );
 
@@ -32,8 +35,10 @@ describe('StartPage', () => {
   it('checks if back-button brings you to the start page', () => {
     const { container } = render(
       <BrowserRouter>
-        <Instructions />
-        <Start />
+        <SettingsProvider>
+          <Instructions />
+          <Start />
+        </SettingsProvider>
       </BrowserRouter>
     );
 

--- a/src/pages/Start.js
+++ b/src/pages/Start.js
@@ -1,43 +1,31 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import SettingsButton from '../components/start/SettingsButton';
 import InstallButton from '../components/start/InstallButton';
 import StartButton from '../components/start/StartButton';
 import HelpButton from '../components/start/HelpButton';
 import LetterTile from '../components/start/LetterTile';
 import './Start.css';
+import { SettingsContext } from '../contexts/SettingsContext';
 
 function Start() {
   const [showInstallButton, setShowInstallButton] = useState(false);
-  const installEventRef = useRef(null);
+
+  const { installEvent, setInstallEvent } = useContext(SettingsContext);
 
   useEffect(() => {
-    const handler = (e) => {
-      e.preventDefault();
-      installEventRef.current = e;
-      setShowInstallButton(true);
-    };
-    window.addEventListener('beforeinstallprompt', handler);
-
-    return () => window.removeEventListener('beforeinstallprompt', handler);
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('appinstalled', () => {
-      setShowInstallButton(false);
-    });
-  }, []);
+    setShowInstallButton(!!installEvent);
+  }, [installEvent]);
 
   const handleInstallClick = async () => {
-    const deferredPrompt = installEventRef.current;
-    if (deferredPrompt) {
-      deferredPrompt.prompt();
-      const { outcome } = await deferredPrompt.userChoice;
+    if (installEvent) {
+      installEvent.prompt();
+      const { outcome } = await installEvent.userChoice;
       if (outcome === 'accepted') {
         console.log('User accepted the install prompt');
       } else {
         console.log('User dismissed the install prompt');
       }
-      installEventRef.current = null; // Reset the prompt
+      setInstallEvent(null);
     }
   };
 

--- a/src/pages/Start.js
+++ b/src/pages/Start.js
@@ -1,15 +1,51 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import SettingsButton from '../components/start/SettingsButton';
+import InstallButton from '../components/start/InstallButton';
 import StartButton from '../components/start/StartButton';
 import HelpButton from '../components/start/HelpButton';
 import LetterTile from '../components/start/LetterTile';
 import './Start.css';
 
 function Start() {
+  const [showInstallButton, setShowInstallButton] = useState(false);
+  const installEventRef = useRef(null);
+
+  useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      installEventRef.current = e;
+      setShowInstallButton(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('appinstalled', () => {
+      setShowInstallButton(false);
+    });
+  }, []);
+
+  const handleInstallClick = async () => {
+    const deferredPrompt = installEventRef.current;
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      if (outcome === 'accepted') {
+        console.log('User accepted the install prompt');
+      } else {
+        console.log('User dismissed the install prompt');
+      }
+      installEventRef.current = null; // Reset the prompt
+    }
+  };
+
   return (
     <div className="start-page">
       <div className="str-top-bar">
         <SettingsButton className="settings-button" />
+        {showInstallButton && <InstallButton onClick={handleInstallClick} />}
       </div>
       <div className="str-center-area">
         <div className="logo">

--- a/src/pages/Start.test.js
+++ b/src/pages/Start.test.js
@@ -11,9 +11,11 @@ describe('StartPage', () => {
   // Rendering the start page
   it('checks if Start-page renders', () => {
     render(
-      <BrowserRouter>
-        <Start />
-      </BrowserRouter>
+      <SettingsProvider>
+        <BrowserRouter>
+          <Start />
+        </BrowserRouter>
+      </SettingsProvider>
     );
   });
 
@@ -41,8 +43,10 @@ describe('StartPage', () => {
     // Rendering the required pages
     const { container } = render(
       <BrowserRouter>
-        <Start />
-        <Instructions />
+        <SettingsProvider>
+          <Start />
+          <Instructions />
+        </SettingsProvider>
       </BrowserRouter>
     );
 
@@ -59,8 +63,10 @@ describe('StartPage', () => {
     // Rendering the required pages
     const { container } = render(
       <BrowserRouter>
-        <Start />
-        <GameMenu />
+        <SettingsProvider>
+          <Start />
+          <GameMenu />
+        </SettingsProvider>
       </BrowserRouter>
     );
 


### PR DESCRIPTION
Toteutettu parempi PWA asennus toiminnallisuus. Nyt asetukset-napin viereen tulee "Install"-nappi, jota painamalla aukeaa selaimen oma PWA asennus dialogi. Käyttäjä voi normaalisti siitä valita haluaako asentaa sovelluksen vai perua. Nappi on saatavilla niin kauan kun sovellus ei ole asennettuna. Sen jälkeen se katoaa näkyvistä.

Selain lähettää tuollaisen `beforeinstallprompt` **kerran** kun sivu ladataan. Tässä toteutuksessa eventtiä kuunnellaan App tasolla, eli missä tahansa routessa. Eventti napataan talteen settings contextiin, jossa se nätisti pysyy vaikka käyttäjä seikkailee missä haluaa. Aloitussivu näyttää napin jos eventti on olemassa. Jos sovellus on jo asennettu, niin tuo toinen selaimen lähettämä eventti poistaa napin näkyvistä.

CSS ratkaisut ovat tietoisia purkkaratkaisuja (käytetään suoraan settings ikonin tyylejä sen nimellä)