### PR TITLE
260 fix papunet filter buttons

### DIFF
--- a/src/components/newWord/PapunetFilterMenu.css
+++ b/src/components/newWord/PapunetFilterMenu.css
@@ -4,6 +4,9 @@
   border: 1px solid var(--sp-gray-sp);
   border-radius: 10px;
   width: 100%;
+  position: relative;
+  z-index: 2000;
+  background-color: var(--sp-white);
 }
 
 .filter-menu-header {

--- a/src/components/newWord/PapunetFilterMenu.css
+++ b/src/components/newWord/PapunetFilterMenu.css
@@ -83,6 +83,21 @@ h3 {
   flex-shrink: 0;
 }
 
+.apply-filters-btn {
+  background-color: var(--sp-dark-green);
+  color: var(--sp-white);
+  border: none;
+  font-size: var(--sp-heading-6);
+  font-weight: bold;
+  border-radius: 8px;
+  padding: 10px 20px;
+  margin-top: 10px;
+  margin-bottom: 30px;
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
 @media (max-width: 768px) {
   .filter-option {
     flex-basis: 100%; /* Switch to one column */

--- a/src/components/newWord/PapunetFilterMenu.js
+++ b/src/components/newWord/PapunetFilterMenu.js
@@ -27,7 +27,7 @@ const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
   const applyFilters = () => {
     onFilterChange(tempFilters);
     setIsOpen(false);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0 });
   };
 
   return (

--- a/src/components/newWord/PapunetFilterMenu.js
+++ b/src/components/newWord/PapunetFilterMenu.js
@@ -27,6 +27,7 @@ const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
   const applyFilters = () => {
     onFilterChange(tempFilters);
     setIsOpen(false);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (

--- a/src/components/newWord/PapunetFilterMenu.js
+++ b/src/components/newWord/PapunetFilterMenu.js
@@ -8,19 +8,25 @@ const public_url = process.env.PUBLIC_URL;
 
 const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [tempFilters, setTempFilters] = useState(selectedFilters);
 
   const toggleMenu = () => setIsOpen((prev) => !prev);
 
   const handleCheckboxChange = (filterKey) => {
-    if (selectedFilters.includes(filterKey)) {
-      onFilterChange(selectedFilters.filter((filter) => filter !== filterKey));
+    if (tempFilters.includes(filterKey)) {
+      setTempFilters(tempFilters.filter((filter) => filter !== filterKey));
     } else {
-      onFilterChange([...selectedFilters, filterKey]);
+      setTempFilters([...tempFilters, filterKey]);
     }
   };
 
   const handleUnselectAll = () => {
-    onFilterChange([]);
+    setTempFilters([]);
+  };
+
+  const applyFilters = () => {
+    onFilterChange(tempFilters);
+    setIsOpen(false);
   };
 
   return (
@@ -46,7 +52,7 @@ const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
                 <input
                   type="checkbox"
                   id={key}
-                  checked={selectedFilters.includes(key)}
+                  checked={tempFilters.includes(key)}
                   onChange={() => handleCheckboxChange(key)}
                 />
                 <span className="filter-label">{label}</span>
@@ -58,6 +64,14 @@ const PapunetFilterMenu = ({ filters, selectedFilters, onFilterChange }) => {
               </label>
             ))}
           </div>
+
+          <button
+            className="apply-filters-btn"
+            onClick={applyFilters}
+            type="button"
+          >
+            KÄYTÄ VALINTOJA
+          </button>
         </div>
       )}
     </div>

--- a/src/components/newWord/PapunetFilterMenu.test.js
+++ b/src/components/newWord/PapunetFilterMenu.test.js
@@ -10,6 +10,7 @@ describe('PapunetFilterMenu', () => {
   };
   const selectedFilters = [];
   const onFilterChange = jest.fn();
+  window.scrollTo = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -50,7 +51,7 @@ describe('PapunetFilterMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('toggles a filter when clicked', () => {
+  test('selects a filter', () => {
     const filters = { filter1: 'Filter 1', filter2: 'Filter 2' };
     const selectedFilters = [];
     const onFilterChange = jest.fn();
@@ -70,11 +71,8 @@ describe('PapunetFilterMenu', () => {
       .closest('.filter-option');
     fireEvent.click(filterOption);
 
+    fireEvent.click(screen.getByText(/käytä valintoja/i));
     expect(onFilterChange).toHaveBeenCalledTimes(1);
-    expect(onFilterChange).toHaveBeenCalledWith(['filter1']);
-
-    fireEvent.click(filterOption);
-    expect(onFilterChange).toHaveBeenCalledTimes(2);
     expect(onFilterChange).toHaveBeenCalledWith(['filter1']);
   });
 
@@ -91,6 +89,7 @@ describe('PapunetFilterMenu', () => {
     const unselectAllButton = screen.getByText(/poista kaikki valinnat/i);
 
     fireEvent.click(unselectAllButton);
+    fireEvent.click(screen.getByText(/käytä valintoja/i));
     expect(onFilterChange).toHaveBeenCalledWith([]);
   });
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
   --sp-black: #232323;
   --sp-light-yellow: #f0d784;
   --sp-red: #8a0a2a;
+  --sp-disabled-gray: #9b9b9b;
 
   /* Fonts */
   --sp-global-font: 'Verdana', sans-serif;

--- a/src/pages/PapunetView.js
+++ b/src/pages/PapunetView.js
@@ -55,6 +55,13 @@ const PapunetView = ({
     }
   }, [getPhotos, initialSearchTerm]);
 
+  // Fetch photos on filter change
+  useEffect(() => {
+    if (initialFetchDone.current) {
+      getPhotos();
+    }
+  }, [selectedFilters, getPhotos]);
+
   const handleFetchPhotos = () => {
     getPhotos();
     initialFetchDone.current = true;

--- a/src/pages/PapunetView.js
+++ b/src/pages/PapunetView.js
@@ -144,7 +144,11 @@ const PapunetView = ({
         <button className="btn-sp-primary return-btn" onClick={closeModal}>
           PERUUTA
         </button>
-        <button className="btn-sp-primary save-btn" onClick={handleSave}>
+        <button
+          className="btn-sp-primary save-btn"
+          onClick={handleSave}
+          disabled={!selectedImage}
+        >
           VALITSE
         </button>
       </div>

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -120,6 +120,10 @@
   font-size: var(--sp-heading-5);
 }
 
+.save-btn:disabled {
+  background-color: #ccc;
+}
+
 .save-btn {
   padding: 15px 20px;
   width: 30%;

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -26,7 +26,7 @@
 
 .search-button {
   padding: 10px 20px;
-  background-color: var(--sp-light-green);
+  background-color: var(--sp-dark-green);
   border: none;
   border-radius: 8px;
   color: var(--sp-white);
@@ -127,7 +127,7 @@
 .save-btn {
   padding: 15px 20px;
   width: 30%;
-  background-color: var(--sp-light-green);
+  background-color: var(--sp-dark-green);
   font-size: var(--sp-heading-5);
 }
 

--- a/src/styles/PapunetView.css
+++ b/src/styles/PapunetView.css
@@ -35,7 +35,7 @@
 }
 
 .search-button:disabled {
-  background-color: #ccc;
+  background-color: var(--sp-disabled-gray);
 }
 
 .photo-container {
@@ -60,7 +60,7 @@
   box-sizing: border-box;
   padding: 10px;
   background-color: var(--sp-white);
-  border: 1px solid #ccc;
+  border: 1px solid var(--sp-gray-sp);
   border-radius: 4px;
   text-align: center;
   transition:
@@ -121,7 +121,7 @@
 }
 
 .save-btn:disabled {
-  background-color: #ccc;
+  background-color: var(--sp-disabled-gray);
 }
 
 .save-btn {


### PR DESCRIPTION
Nopee fiksi ongelmalle, että käyttäjä haluisi painaa VALMIS-nappia kuvafiltterien käyttämiseen kuvahaussa:
- PapunetFilterMenu-komponentti menee nappien päälle, niin niitä ei houkuttele heti painaa
- PapunetView VALMIS-nappi on disabloitu ennen kuin käyttäjä on valinnut kuvan
- Komponentin alalaidassa KÄYTÄ-nappi, jota klikkaamalla kuvat haetaan valittuja filttereitä käyttäen