### PR TITLE
261 fix cropping tool functionality

### DIFF
--- a/src/components/newWord/ImageCropper.js
+++ b/src/components/newWord/ImageCropper.js
@@ -47,8 +47,8 @@ const ImageCropper = ({
               zoomable={true}
               movable={true}
               cropBoxResizable={false}
-              cropBoxMovable={true}
-              dragMode="none"
+              cropBoxMovable={false}
+              dragMode="move"
               viewMode={0}
               ref={cropperRef}
             />


### PR DESCRIPTION
Tässä issuessa piti muokata kuvien rajaustyökalun toiminnallisuutta siten, että kuvaa pystyy siirtää, mutta rajausneliötä ei. Closes #261 