### PR TITLE
282 fix cropping tools back button functionality

### DIFF
--- a/src/components/create/WordRow.js
+++ b/src/components/create/WordRow.js
@@ -7,7 +7,12 @@ const WordRow = ({ word, imgSrc, onDelete, onEdit }) => {
   return (
     <div className="word-row-container">
       <span className="word-text">{word}</span>
-      <img src={imgSrc || '/mrBean.png'} alt={word} className="word-image" />
+      <img
+        src={imgSrc || '/mrBean.png'}
+        alt={word}
+        className="word-image"
+        style={{ marginRight: '10px' }}
+      />
       <EditButton onClick={onEdit} />
       <DeleteButton onClick={onDelete} />
     </div>

--- a/src/components/create/WordRow.js
+++ b/src/components/create/WordRow.js
@@ -7,12 +7,7 @@ const WordRow = ({ word, imgSrc, onDelete, onEdit }) => {
   return (
     <div className="word-row-container">
       <span className="word-text">{word}</span>
-      <img
-        src={imgSrc || '/mrBean.png'}
-        alt={word}
-        className="word-image"
-        style={{ paddingRight: '10px' }}
-      />
+      <img src={imgSrc || '/mrBean.png'} alt={word} className="word-image" />
       <EditButton onClick={onEdit} />
       <DeleteButton onClick={onDelete} />
     </div>

--- a/src/pages/NewWord.js
+++ b/src/pages/NewWord.js
@@ -212,7 +212,10 @@ const NewWord = () => {
             key={imageData.src}
             imageSrc={imageData.src}
             onCroppedImage={handleImageCrop}
-            onBack={() => setIsCropping(false)}
+            onBack={() => {
+              setIsCropping(false);
+              setImageData(null);
+            }}
             imageSource={imageSource}
             reopenFileSelector={reopenFileSelector}
           />


### PR DESCRIPTION
Tässä issuessa oli tarkoitus korjata kuvien rajausmodaalin takaisin painikkeen logiikkaa. Aiemmin takaisin painikkeiden kautta palatessa ja kuvan jättämällä tyhjäksi tallentui tietokantaan viimeisimmäksi valittu kuva rajaamattomana. Nyt jos kuvan jättää rajaamatta takaisin painikkeiden kautta, jää kuvien data tyhjäksi. Samalla korjasin sanalistojen kuvakoot neliöiksi. Closes #282 