### PR TITLE
28 enhance the UI

### DIFF
--- a/src/components/game/GameEngine.css
+++ b/src/components/game/GameEngine.css
@@ -1,50 +1,38 @@
-.game-engine {
-    background-color: #06705b;
-    height: 100vh;
-    display: grid;
-    grid-template-areas: 'back-button';
-}
-
 .loading-msg .error-msg {
-    color: white;
-    font-size: var(--sp-heading-1);
-}
-
-.game-engine h2 {
-    color: white;
-    font-size: var(--sp-heading-1);
+  color: white;
+  font-size: var(--sp-heading-1);
 }
 
 .top-bar {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    justify-content: space-between;
-    margin-bottom: 25px;
-    padding-top: 11px;
-    padding-left: 9px;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: space-between;
+  margin-bottom: 25px;
+  padding-top: 11px;
+  padding-left: 9px;
 }
 
 .progress-bar-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
 }
 
 .game-back-button {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    position: absolute;
-    grid-area: back-button;
-    width: 100px;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  position: absolute;
+  grid-area: back-button;
+  width: 100px;
 }
 
 .game-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/components/universal/Header.css
+++ b/src/components/universal/Header.css
@@ -14,7 +14,11 @@
     font-family: var(--sp-global-font);
     font-size: var(--sp-heading-1);
     font-weight: 700;
-    line-height: 44px;
+    max-width: 60vw;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .header-center {

--- a/src/index.css
+++ b/src/index.css
@@ -53,7 +53,7 @@ code {
 }
 
 .btn-sp-primary {
-  @apply text-sp-white font-bold text-2xl rounded-sp-button p-4 lg:p-8;
+  @apply text-sp-white font-bold text-2xl rounded-sp-button p-4;
 }
 
 .btn-sp-secondary {

--- a/src/styles/GameMenu.css
+++ b/src/styles/GameMenu.css
@@ -110,10 +110,6 @@
 
 /* Style for phones in horizontal mode */
 @media (max-height: 450px) {
-  .game-menu-page {
-    background-image: none;
-  }
-
   .word-image {
     margin-right: 10px;
   }

--- a/src/styles/GameMenu.css
+++ b/src/styles/GameMenu.css
@@ -5,8 +5,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  background-image: 
-    url('../../public/app_background.png');
+  background-image: url('../../public/app_background.png');
   background-repeat: repeat;
   background-position: center;
 }
@@ -14,21 +13,6 @@
 .game-menu-page .header {
   padding: 25px 25px;
   margin-bottom: 0px;
-}
-
-.button-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  width: 100%;
-  max-width: 800px;
-  max-height: 60vh;
-  row-gap: 20px;
-  padding: 20px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  background-color: #06705B;
 }
 
 .game-menu-page .header-right {
@@ -51,7 +35,6 @@
   padding: 20px;
   overflow-y: auto;
   overflow-x: hidden;
-  background-color: #06705B;
 }
 
 .button-item-container {
@@ -105,7 +88,6 @@
   .word-image {
     margin-right: 0;
   }
-
 }
 
 /* Style for phones in horizontal mode */
@@ -113,5 +95,4 @@
   .word-image {
     margin-right: 10px;
   }
-
 }

--- a/src/styles/ManagePath.css
+++ b/src/styles/ManagePath.css
@@ -111,10 +111,6 @@
 
 /* Style for phones in horizontal mode */
 @media (max-height: 450px) {
-  .manage-page {
-    background-image: none;
-  }
-
   .word-image {
     margin-right: 10px;
   }

--- a/src/styles/ManagePath.css
+++ b/src/styles/ManagePath.css
@@ -5,8 +5,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  background-image: 
-    url('../../public/app_background.png');
+  background-image: url('../../public/app_background.png');
   background-repeat: repeat;
   background-position: center;
 }
@@ -24,7 +23,6 @@
   justify-content: flex-start;
   width: 100%;
   max-height: 60vh;
-  background-color: #06705B;
 }
 
 .word-list {
@@ -90,7 +88,7 @@
 }
 
 /* Style for phones in portrait mode */
-@media (max-width: 767px) { 
+@media (max-width: 767px) {
   .delete-icon {
     font-size: var(--sp-icon-size-extra-small);
   }
@@ -106,7 +104,6 @@
   .word-image {
     margin-right: 0;
   }
-
 }
 
 /* Style for phones in horizontal mode */
@@ -114,5 +111,4 @@
   .word-image {
     margin-right: 10px;
   }
-
 }

--- a/src/styles/PathSelection.css
+++ b/src/styles/PathSelection.css
@@ -70,6 +70,10 @@
   border-radius: var(--sp-button-border-radius) 0 0
     var(--sp-button-border-radius);
   cursor: pointer;
+  display: inline-block;
+  white-space: normal;
+  word-break: break-word; 
+  margin-right: 5px;
 }
 
 .path-item-container:hover {

--- a/src/styles/PathSelection.css
+++ b/src/styles/PathSelection.css
@@ -176,10 +176,3 @@
   border: 2px solid;
   border-radius: 5px;
 }
-
-/* Style for phones in horizontal mode */
-@media (max-height: 450px) {
-  .paths-page {
-    background-image: none;
-  }
-}

--- a/src/styles/PathSelection.css
+++ b/src/styles/PathSelection.css
@@ -27,7 +27,6 @@
   padding: 20px;
   overflow-y: auto;
   overflow-x: hidden;
-  background-color: #06705b;
 }
 
 .paths-page .header .edit-button {
@@ -72,7 +71,7 @@
   cursor: pointer;
   display: inline-block;
   white-space: normal;
-  word-break: break-word; 
+  word-break: break-word;
   margin-right: 5px;
 }
 


### PR DESCRIPTION
Fixattu:

- Kännykällä vaakatasossa kuusitausta näkyviin, jos ei ole polkuja: Ei onnistunut eritellä, joten nyt aina näkyvissä ja saattaa jäädä elementtien taakse piiloon, jolloin ei näy

- Hitusen pidemmällä polun nimellä kännykällä editointi, poisto ja jakonapit liukuvat ulos ruudusta, jolloin niitä ei voi enää käyttää (Kuva kommenteissa). Mallia voi varmaankin ottaa pitkän sanan käsittelystä polun muokkauksen sivulta: Jakautuu nyt uudelle riville, kuten sanalistoissakin

- Polun jakamisen vastaanottamisen ponnahdusikkunassa Palaa Takaisin nappia voisi pienentää (ei näy ainakaan Juhon tabletilla kokonaan :D): Pienennetty, onko tarpeeksi?

Closes #28 